### PR TITLE
Maintain width/height of dragged element

### DIFF
--- a/src/draggable.js
+++ b/src/draggable.js
@@ -270,6 +270,8 @@
         style.display = 'block';
         style.left = _dimensions.left + 'px';
         style.top = _dimensions.top + 'px';
+        style.width = _dimensions.width + 'px';
+        style.height = _dimensions.height + 'px';
         style.bottom = style.right = 'auto';
         style.margin = 0;
         style.position = 'absolute';


### PR DESCRIPTION
Currently, if an element does not have a width/height and assumes the parent
element's width/height, when the element becomes a `Draggable` it changes the
size of the element.

This PR fixes this, and lets the element to maintain its width/height once it becomes
a `Draggable`

Here is how it is currently: https://codepen.io/shuanwang/pen/OQBgBX
Here is the fix: https://codepen.io/shuanwang/pen/OQBgeb

You can see the difference if you comment out the `Draggable` instantiation in the first codepen.