### PR TITLE
fix set

### DIFF
--- a/src/draggable.js
+++ b/src/draggable.js
@@ -148,7 +148,11 @@
 
     // set instance properties
     util.assign(me, {
-
+      dragEvent: {
+        started: false,
+        x: 0,
+        y: 0,
+      },
       // DOM element
       element: element,
       handle: (options.handle && isElement(options.handle))


### PR DESCRIPTION
Create multiple objects，each of  which use the "set" method to set the same location. The first set succeeds and the next set fails.
 
the set method calls the move method, and the condition of the move is: pos.x! == dragEvent.x || pos.y ! == dragEvent.y。 dragEvent  is a property of prototype ，so each draggable object point a dragEvent .
